### PR TITLE
Helpers

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -3,4 +3,5 @@ module.exports = {
   spec: 'tests/*.spec.js',
   ignore: 'tests/example.spec.js',
   file: 'config/setup.js',
+  timeout: 15000,
 }

--- a/config/setup.js
+++ b/config/setup.js
@@ -1,9 +1,8 @@
 import 'dotenv/config'
-import supertest from 'supertest'
+import AuthHelper from '../helpers/auth.helper'
 
 before(async function () {
-  const response = await supertest(process.env.BASE_URL)
-    .post('/auth')
-    .send({login: process.env.LOGIN, password: process.env.PASSWORD})
-  process.env['TOKEN'] = response.body.token
+  const authHelper = new AuthHelper()
+  await authHelper.logIn(process.env.LOGIN, process.env.PASSWORD)
+  process.env['TOKEN'] = authHelper.result.body.token
 })

--- a/helpers/auth.helper.js
+++ b/helpers/auth.helper.js
@@ -1,0 +1,12 @@
+import supertest from 'supertest'
+
+export default class AuthHelper {
+  result
+
+  async logIn(login, password) {
+    this.result = await supertest(process.env.BASE_URL)
+      .post('/auth')
+      .send({login, password})
+    return this.result
+  }
+}

--- a/tests/auth.spec.js
+++ b/tests/auth.spec.js
@@ -1,14 +1,14 @@
-import supertest from 'supertest'
 import {expect} from 'chai'
+import AuthHelper from '../helpers/auth.helper'
 
 describe('Authentication', function () {
+  const authHelper = new AuthHelper()
+
   describe('Log in with valid credentials', function () {
     let response
 
     before(async function () {
-      response = await supertest(process.env.BASE_URL)
-        .post('/auth')
-        .send({login: process.env.LOGIN, password: process.env.PASSWORD})
+      response = await authHelper.logIn(process.env.LOGIN, process.env.PASSWORD)
     })
 
     it('Response status code is 200', function () {
@@ -24,9 +24,7 @@ describe('Authentication', function () {
     let response
 
     before(async function () {
-      response = await supertest(process.env.BASE_URL)
-        .post('/auth')
-        .send({login: 'invalid', password: 'invalid'})
+      response = await authHelper.logIn('invalid', 'invalid')
     })
 
     it('Response status code is 404', function () {


### PR DESCRIPTION
### Overall
**DRY** (**D**on't **R**epeat **Y**ourself) being implemented here as class/function helpers - code becomes reusable and more readable.

### Changes
- added test timeout in **mocha** config
- added helper that sends a request to `/auth` endpoint
- updated `Authentication` spec to use `AuthHelper`
- updated global (authentication) setup to use `AuthHelper`