### PR TITLE
Create User tests

### DIFF
--- a/helpers/user.helper.js
+++ b/helpers/user.helper.js
@@ -1,0 +1,20 @@
+import supertest from 'supertest'
+
+export default class UserHelper {
+  result
+
+  async create() {
+    this.result = await supertest(process.env.BASE_URL)
+      .post('/users')
+      .set('Authorization', `Bearer ${process.env.TOKEN}`)
+    return this.result
+  }
+
+  async delete(id) {
+    this.result = await supertest(process.env.BASE_URL)
+      .delete('/users')
+      .set('Authorization', `Bearer ${process.env.TOKEN}`)
+      .send({id})
+    return this.result
+  }
+}

--- a/tests/user.spec.js
+++ b/tests/user.spec.js
@@ -1,0 +1,29 @@
+import UserHelper from '../helpers/user.helper'
+import {expect} from 'chai'
+
+describe.only('User', function () {
+  describe('Create', function () {
+    let response
+    const userHelper = new UserHelper()
+
+    before(async function () {
+      response = await userHelper.create()
+    })
+
+    after(async function () {
+      await userHelper.delete(response.body.id)
+    })
+
+    it('Response status code is 200', function () {
+      expect(response.statusCode).to.eq(200)
+    })
+
+    it('Response body contains User ID', function () {
+      expect(response.body.id).to.be.a('string')
+    })
+
+    it('Response body contains amount', function () {
+      expect(response.body.amount).to.be.a('number')
+    })
+  })
+})


### PR DESCRIPTION
### Overall
User creation tests - `/users` endpoint.

### Changes
- added `UserHelper` with `create` and `delete` methods
- added `User` spec with `Create` test suite